### PR TITLE
add darwin support

### DIFF
--- a/nix-top
+++ b/nix-top
@@ -67,27 +67,28 @@ end
 # or not it can peek into processes.
 def get_out_path(user, pid)
   begin
-    file = "/proc/#{pid}/environ"
+  # whew!
+  build_dir = `find -L /tmp -maxdepth 1 -user #{user.shellescape} -exec stat --printf '%Z:%n\\n' '{}' ';' | sort -n`
+    .strip
+    .split("\n")
+    .last
+    .split(":")
+    .last
+  rescue
+    "(unknown)"
+  end
+  begin
+    file = "#{build_dir}/env-vars"
     # This can fail if the process disappears while trying to read.
     # This is why we rescue everything
     # (This also could fail due to missing `out=` and we get free rescue)
     File.read(file)                          # Reads process' environment
-      .split("\0")                           # (which is a null-delimited list)
-      .grep(/^out=/)                         # Keep out paths
+      .split("\n")                           # (which is a null-delimited list)
+      .grep(/^declare -x out=/)              # Keep out paths
       .first                                 # Keep the only result
-      .split("=", 2).last                    # Keep only the value
+      .split("\"").last                      # Keep only the value
   rescue
-    begin
-    # whew!
-    `find /tmp -maxdepth 1 -user #{user.shellescape} -exec stat --printf '%Z:%n\\n' '{}' ';' | sort -n`
-      .strip
-      .split("\n")
-      .last
-      .split(":")
-      .last
-    rescue
-      "(unknown)"
-    end
+    build_dir
   end
 end
 

--- a/nix-top
+++ b/nix-top
@@ -31,14 +31,12 @@ def stty(*flags)
 end
 
 # Returns [width, height] of the terminal.
-def size()
+def size
   `echo 'cols\nlines' | tput -S`.strip.split("\n").map(&:to_i)
 end
 
-def build_users()
-  File.read("/etc/passwd").strip().split("\n").grep(/^nixbld\d+:/).map do |line|
-    line.split(":").first
-  end
+def build_users
+  `getent group nixbld`.strip.split(":").last.split(",")
 end
 
 def active_build_users()
@@ -96,7 +94,7 @@ end
 def per_output_infos(user, pids, path)
   [
     ":: (%s) → %s" % [user, path],
-    `ps -eLf -q "#{pids.join(",").shellescape}"`
+    `ps -o uid,pid,ppid,stime,time,command -U "#{user.shellescape}"`
   ]
 end
 

--- a/nix-top.nix
+++ b/nix-top.nix
@@ -2,8 +2,9 @@
 , lib
 , ruby
 , makeWrapper
-, procps               # ps
+, getent               # /etc/passwd
 , ncurses              # tput
+, procps               # ps
 , binutils-unwrapped   # strings
 , findutils
 }:
@@ -21,8 +22,8 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
 
-  ADDITIONAL_PATH = lib.makeBinPath [ncurses procps binutils-unwrapped findutils];
-  
+  ADDITIONAL_PATH = lib.makeBinPath [ getent ncurses binutils-unwrapped findutils ];
+
   installPhase = ''
     mkdir -p $out/bin/
     cp ./nix-top $out/bin/nix-top

--- a/nix-top.nix
+++ b/nix-top.nix
@@ -6,6 +6,7 @@
 , ncurses              # tput
 , procps               # ps
 , binutils-unwrapped   # strings
+, coreutils
 , findutils
 }:
 
@@ -22,7 +23,7 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
 
-  ADDITIONAL_PATH = lib.makeBinPath [ getent ncurses binutils-unwrapped findutils ];
+  ADDITIONAL_PATH = lib.makeBinPath [ getent ncurses binutils-unwrapped coreutils findutils ];
 
   installPhase = ''
     mkdir -p $out/bin/

--- a/nix-top.nix
+++ b/nix-top.nix
@@ -26,10 +26,12 @@ stdenv.mkDerivation rec {
   ADDITIONAL_PATH = lib.makeBinPath [ getent ncurses binutils-unwrapped coreutils findutils ];
 
   installPhase = ''
-    mkdir -p $out/bin/
+    mkdir -p $out/bin $out/libexec/nix-top
     cp ./nix-top $out/bin/nix-top
     chmod +x $out/bin/nix-top
     wrapProgram $out/bin/nix-top \
-      --prefix PATH : "${ADDITIONAL_PATH}"
+      --prefix PATH : "$out/libexec/nix-top:${ADDITIONAL_PATH}"
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    ln -s /bin/stty $out/libexec/nix-top
   '';
 }


### PR DESCRIPTION
Most notable changes:
- use getent instead of relying on /etc/passwd
- use /tmp/nix-build-foo-0/env-vars instead of /proc/<pid>/environ

The rest are some minor stuff like avoiding flags that only exist for the linux variants of procps, etc.