### PR TITLE
Use lib instead of stdenv.lib

### DIFF
--- a/nix-top.nix
+++ b/nix-top.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     install -D -m755 ./nix-top $out/bin/nix-top
     wrapProgram $out/bin/nix-top \
       --prefix PATH : "$out/libexec/nix-top:${additionalPath}"
-  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     ln -s /bin/stty $out/libexec/nix-top
   '';
 


### PR DESCRIPTION
The latter is deprecated, so now emits a warning on latest nix (see https://github.com/NixOS/nixpkgs/issues/108938)